### PR TITLE
Rpm support

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -601,4 +601,11 @@ eval "$(starship init bash)"
 
 #Autojump
 
-. /usr/share/autojump/autojump.sh
+if [ -f "/usr/share/autojump/autojump.sh" ]; then
+	. /usr/share/autojump/autojump.sh
+elif [ -f "/usr/share/autojump/autojump.bash" ]; then
+	. /usr/share/autojump/autojump.bash
+else
+	echo "can't found the autojump script"
+fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -31,9 +31,15 @@ installDepend(){
     ## Check for dependencies.
     DEPENDENCIES='autojump bash bash-completion'
     echo -e "${YELLOW}Installing dependencies...${RC}"
-    sudo dpkg --configure -a
-    sudo apt-get install -fyq ${DEPENDENCIES}
-    sudo dpkg --configure -a
+    if [[  -x "/usr/bin/apt-get" ]]; then
+        sudo dpkg --configure -a
+        sudo apt-get install -fyq ${DEPENDENCIES}
+        sudo dpkg --configure -a
+    elif [[  -x "/usr/bin/yum" ]]; then
+        sudo yum install -fyq ${DEPENDENCIES}
+    else
+        echo "Can't check the package manager to use"
+    fi
 }
 
 installStarship(){

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ checkEnv(){
         exit 1
     fi
 
-    if [[ ! -x "/usr/bin/apt-get" ]] || [[ ! -x "/usr/bin/yum" ]]; then
+    if [[ ! -x "/usr/bin/apt-get" ]] && [[ ! -x "/usr/bin/yum" ]]; then
         echo -e "Can't find a supported package manager"
         exit 1
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ checkEnv(){
     fi
 
     ## Check for requirements.
-    REQUIREMENTS='curl apt groups sudo'
+    REQUIREMENTS='curl groups sudo'
     if ! which ${REQUIREMENTS}>/dev/null;then
         echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
         exit 1
@@ -25,20 +25,24 @@ checkEnv(){
         echo -e "${RED}You need to be a member of the sudo group to run me!"
         exit 1
     fi
+
+    if [[ ! -x "/usr/bin/apt-get" ]] || [[ ! -x "/usr/bin/yum" ]]; then
+        echo -e "Can't find a supported package manager"
+        exit 1
+    fi
+    
 }
 
 installDepend(){
     ## Check for dependencies.
-    DEPENDENCIES='autojump bash bash-completion'
+    DEPENDENCIES='autojump bash bash-completion tar neovim'
     echo -e "${YELLOW}Installing dependencies...${RC}"
     if [[  -x "/usr/bin/apt-get" ]]; then
         sudo dpkg --configure -a
         sudo apt-get install -fyq ${DEPENDENCIES}
         sudo dpkg --configure -a
     elif [[  -x "/usr/bin/yum" ]]; then
-        sudo yum install -fyq ${DEPENDENCIES}
-    else
-        echo "Can't check the package manager to use"
+        sudo yum install -yq ${DEPENDENCIES}
     fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ checkEnv(){
         exit 1
     fi
 
-    if [[ ! -x "/usr/bin/apt-get" ]] && [[ ! -x "/usr/bin/yum" ]]; then
+    if [[ ! -x "/usr/bin/apt-get" ]] && [[ ! -x "/usr/bin/yum" ]] && [[ ! -x "/usr/bin/dnf" ]]; then
         echo -e "Can't find a supported package manager"
         exit 1
     fi
@@ -43,6 +43,8 @@ installDepend(){
         sudo dpkg --configure -a
     elif [[  -x "/usr/bin/yum" ]]; then
         sudo yum install -yq ${DEPENDENCIES}
+    elif [[  -x "/usr/bin/dnf" ]]; then
+        sudo dnf install -yq ${DEPENDENCIES}
     fi
 }
 


### PR DESCRIPTION
Adds support for RPM based distros like fedora. Inspired by this PR https://github.com/ChrisTitusTech/mybash/pull/3 and since day one that I watched the video, I thought about this but didn't tested until now. Tested on a Fedora 36 VM

To be noticed, I added tar as a dependency, because on a fresh minimal install, the setup.sh failed for this missing program. And I include neovim because as default due the aliases, changes any CLI text editor to that and isn't installed by default.