### PR TITLE
Update .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -39,7 +39,7 @@ shopt -s histappend
 PROMPT_COMMAND='history -a'
 
 # Allow ctrl-S for history navigation (with ctrl-R)
-stty -ixon
+[[ $- == *i* ]] && stty -ixon
 
 # Ignore case on auto-completion
 # Note: bind used instead of sticking these in .inputrc


### PR DESCRIPTION
I install this on a fresh ubuntu 22.10 on a Lenovo Thinkpad T590.
I was unable to login , via Desktop the system present a error "stty: 'standard input': inapropriated iocl for device" and has a button ok but I was unable to click it.

After some debug I found a solution :) 
# Allow ctrl-S for history navigation (with ctrl-R)
**[[ $- == *i* ]] &&** stty -ixon