### PR TITLE
One script to rule them all. Arch support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,12 @@ checkEnv() {
         fi
     done
 
+    if [ -z "${PACKAGER}" ]; then
+        echo -e "${RED}Can't find a supported package manager"
+        exit 1
+    fi
+
+
     ## Check if the current directory is writable.
     GITPATH="$(dirname "$(realpath "$0")")"
     if [[ ! -w ${GITPATH} ]]; then
@@ -41,11 +47,6 @@ checkEnv() {
     ## Check if member of the sudo group.
     if ! groups | grep ${SUGROUP} >/dev/null; then
         echo -e "${RED}You need to be a member of the sudo group to run me!"
-        exit 1
-    fi
-
-    if [[ ! -x "/usr/bin/apt-get" ]] && [[ ! -x "/usr/bin/yum" ]] && [[ ! -x "/usr/bin/dnf" ]]; then
-        echo -e "Can't find a supported package manager"
         exit 1
     fi
     

--- a/setup.sh
+++ b/setup.sh
@@ -64,8 +64,7 @@ installDepend() {
         if ! command_exists yay; then
             echo "Installing yay..."
             sudo ${PACKAGER} --noconfirm -S base-devel
-            $(cd /opt && sudo git clone https://aur.archlinux.org/yay-git.git && sudo chown -R ${USER}:${USER} ./yay-git)
-            makepkg -si
+            $(cd /opt && sudo git clone https://aur.archlinux.org/yay-git.git && sudo chown -R ${USER}:${USER} ./yay-git && cd yay-git && makepkg -si)
         else
             echo "Command yay already installed"
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ installDepend() {
     ## Check for dependencies.
     DEPENDENCIES='autojump bash bash-completion tar neovim'
     echo -e "${YELLOW}Installing dependencies...${RC}"
-    if [[ $PACKAGER -eq "pacman" ]]; then
+    if [[ $PACKAGER == "pacman" ]]; then
         if ! command_exists yay; then
             echo "Installing yay..."
             sudo ${PACKAGER} --noconfirm -S base-devel

--- a/setup.sh
+++ b/setup.sh
@@ -64,7 +64,7 @@ installDepend() {
         if ! command_exists yay; then
             echo "Installing yay..."
             sudo ${PACKAGER} --noconfirm -S base-devel
-            $(cd /opt && sudo git clone https://aur.archlinux.org/yay-git.git && sudo chown -R ${USER}:${USER} ./yay-git && cd yay-git && makepkg -si)
+            $(cd /opt && sudo git clone https://aur.archlinux.org/yay-git.git && sudo chown -R ${USER}:${USER} ./yay-git && cd yay-git && makepkg --noconfirm -si)
         else
             echo "Command yay already installed"
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,14 @@ RED='\e[31m'
 YELLOW='\e[33m'
 GREEN='\e[32m'
 
+command_exists () {
+    command -v $1 >/dev/null 2>&1;
+}
+
 checkEnv() {
     ## Check for requirements.
-    REQUIREMENTS='curl groups sudo which'
-    if ! which ${REQUIREMENTS} >/dev/null; then
+    REQUIREMENTS='curl groups sudo'
+    if ! command_exists ${REQUIREMENTS}; then
         echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
         exit 1
     fi
@@ -16,7 +20,7 @@ checkEnv() {
     ## Check Package Handeler
     PACKAGEMANAGER='apt dnf pacman'
     for pgm in ${PACKAGEMANAGER}; do
-        if which ${pgm} >/dev/null; then
+        if command_exists ${pgm}; then
             PACKAGER=${pgm}
             echo -e "Using ${pgm}"
         fi
@@ -57,22 +61,22 @@ installDepend() {
     DEPENDENCIES='autojump bash bash-completion tar neovim'
     echo -e "${YELLOW}Installing dependencies...${RC}"
     if [[ $PACKAGER -eq "pacman" ]]; then
-        YAY_CMD==$(which yay)
-        if [[ -z $YAY_CMD ]]; then
+        if ! command_exists yay; then
             echo "Installing yay..."
             sudo ${PACKAGER} --noconfirm -S base-devel
             $(cd /opt && sudo git clone https://aur.archlinux.org/yay-git.git && sudo chown -R ${USER}:${USER} ./yay-git)
             makepkg -si
+        else
+            echo "Command yay already installed"
         fi
-    	sudo yay --noconfirm -S ${DEPENDENCIES}
+    	yay --noconfirm -S ${DEPENDENCIES}
     else 
     	sudo ${PACKAGER} install -yq ${DEPENDENCIES}
     fi
 }
 
 installStarship(){
-    STARSHIP_CMD==$(which starship)
-    if [[ ! -z $STARSHIP_CMD ]]; then
+    if command_exists starship; then
         echo "Starship already installed"
         return
     fi


### PR DESCRIPTION
I thought that having a separated setup file just for arch, can be improved and have a single script that can be run in any distro base and the only thing left for everyone, it's to customize the bashrc file as they wish. So, I was trying to archive this and maybe this is a good solution.

My changes in details.
1. I removed all the which commands usages because which is not installed by default on a minimal arch install VM, it's installed as a dependency for other package, but also has some inconsistency of checking if a program is available with the latest version. At line 667 https://cvs.savannah.gnu.org/viewvc/which/which/which.c?view=markup#l667 makes a stderr output when a program is not found, instead of no output that other distros have it by default. So, searching for a more wide supported way to do the same thing, I found that 'command' is one way to go. I include some stackoverflow posts that I got for it.
https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script
https://stackoverflow.com/questions/36715138/how-to-check-if-command-v-1-dev-null-21-is-false

2. Allow yay to be installed using the script and make sure that autojump can be installed using the AUR. The installation process is based on the git documentation and also moving the files to be used into the /opt directory.
3. No sudo for yay command, for some reason, when tries to install autojump, fails because a permission denied error.  Also, yay prompts a message that is not recommended to use with sudo.
4. Add --noconfirm flag to pacman and yay commands. Archives the same when using -y with apt or dnf commands.

Tested on the latest Archlinux VM and also tested with the Fedora VM that I have, just to make sure to not break anything.