### PR TITLE
kitty alias

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -208,6 +208,10 @@ alias sha1='openssl sha1'
 
 alias clickpaste='sleep 3; xdotool type "$(xclip -o -selection clipboard)"'
 
+# KITTY - alias to be able to use kitty features when connecting to remote servers(e.g use tmux on remote server)
+
+alias s="kitty +kitten ssh"
+
 #######################################################
 # SPECIAL FUNCTIONS
 #######################################################

--- a/.bashrc
+++ b/.bashrc
@@ -210,7 +210,7 @@ alias clickpaste='sleep 3; xdotool type "$(xclip -o -selection clipboard)"'
 
 # KITTY - alias to be able to use kitty features when connecting to remote servers(e.g use tmux on remote server)
 
-alias s="kitty +kitten ssh"
+alias kssh="kitty +kitten ssh"
 
 #######################################################
 # SPECIAL FUNCTIONS


### PR DESCRIPTION
Recently in konsole from KDE i came across the problem os using tmux selecion copy on a remote server. In the forum I found that the problem is lack of OSC-52 support 
https://forum.kde.org/viewtopic.php?f=227&t=174243
Since you recommend kitty and it will be the primary choice of most users maybe it would be useful to have that here. 