### PR TITLE
Updated whatsmyip command.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -484,12 +484,24 @@ function whatsmyip ()
 {
 	# Dumps a list of all IP addresses for every device
 	# /sbin/ifconfig |grep -B1 "inet addr" |awk '{ if ( $1 == "inet" ) { print $2 } else if ( $2 == "Link" ) { printf "%s:" ,$1 } }' |awk -F: '{ print $1 ": " $3 }';
-
+	
+	### Old commands
 	# Internal IP Lookup
-	echo -n "Internal IP: " ; /sbin/ifconfig eth0 | grep "inet addr" | awk -F: '{print $2}' | awk '{print $1}'
+	#echo -n "Internal IP: " ; /sbin/ifconfig eth0 | grep "inet addr" | awk -F: '{print $2}' | awk '{print $1}'
+#
+#	# External IP Lookup
+	#echo -n "External IP: " ; wget http://smart-ip.net/myip -O - -q
+	
+	# Internal IP Lookup.
+	if [ -e /sbin/ip ];
+	then
+		echo -n "Internal IP: " ; /sbin/ip addr show wlan0 | grep "inet " | awk -F: '{print $1}' | awk '{print $2}'
+	else
+		echo -n "Internal IP: " ; /sbin/ifconfig wlan0 | grep "inet " | awk -F: '{print $1} |' | awk '{print $2}'
+	fi
 
-	# External IP Lookup
-	echo -n "External IP: " ; wget http://smart-ip.net/myip -O - -q
+	# External IP Lookup 
+	echo -n "External IP: " ; curl -s ifconfig.me
 }
 
 # View Apache logs


### PR DESCRIPTION
The `whatsmyip` / `whatismyip` command doesn't work on distros that use /sbin/ip instead of /sbin/ifconfig. I took a look at it since it also wasn't showing the external IP address and took some time to update it so that it works again.

You may want to change `wlan0` back to `eth0`, as I was having to do it over a wifi connection at the time. I hope this is useful!