### PR TITLE
Fixed sorting in ls aliases

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -156,8 +156,8 @@ alias la='ls -Alh'                # show hidden files
 alias ls='ls -aFh --color=always' # add colors and file type extensions
 alias lx='ls -lXBh'               # sort by extension
 alias lk='ls -lSrh'               # sort by size
-alias lc='ls -lcrh'               # sort by change time
-alias lu='ls -lurh'               # sort by access time
+alias lc='ls -ltcrh'              # sort by change time
+alias lu='ls -lturh'              # sort by access time
 alias lr='ls -lRh'                # recursive ls
 alias lt='ls -ltrh'               # sort by date
 alias lm='ls -alh |more'          # pipe through 'more'


### PR DESCRIPTION
Made changes so that when using `lc` and `lu` to sort `ls` by 'change time' and 'access time' respectively, it actually sorts it instead of displaying the information and sorting alphabetically.