### PR TITLE
Update starship.toml

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -44,7 +44,7 @@ truncation_symbol = "…/"
 # Here is how you can shorten some long paths by text replacement
 # similar to mapped_locations in Oh My Posh:
 [directory.substitutions]
-"Documents" = " "
+"Documents" = "󰈙 "
 "Downloads" = " "
 "Music" = " "
 "Pictures" = " "


### PR DESCRIPTION
replaced the Documents icon with a new one since its already been removed in the Official Nerd Fonts

OLD
![image](https://github.com/ChrisTitusTech/mybash/assets/97221303/ccaace95-fd6f-43ae-b078-b4d7bebb3b2e)

NEW
![image](https://github.com/ChrisTitusTech/mybash/assets/97221303/804f2398-030e-47f7-8b94-43588a36d9fa)
