### PR TITLE
feat(distribution function): added ID_LIKE check

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -366,7 +366,31 @@ distribution ()
 				dtype="slackware"
 				;;
 			*)
-				# If ID is not recognized, keep dtype as unknown
+				# Check ID_LIKE only if dtype is still unknown
+				if [ -n "$ID_LIKE" ]; then
+					case $ID_LIKE in
+						*fedora*|*rhel*|*centos*)
+							dtype="redhat"
+							;;
+						*sles*|*opensuse*)
+							dtype="suse"
+							;;
+						*ubuntu*|*debian*)
+							dtype="debian"
+							;;
+						*gentoo*)
+							dtype="gentoo"
+							;;
+						*arch*)
+							dtype="arch"
+							;;
+						*slackware*)
+							dtype="slackware"
+							;;
+					esac
+				fi
+
+				# If ID or ID_LIKE is not recognized, keep dtype as unknown
 				;;
 		esac
 	fi


### PR DESCRIPTION
After trying out the script in my system i realized i wasn't able to use install_bashrc_support and realized that the check for the distribution was only being done through the ID field i added a way to check through ID_LIKE at the default case to check ID_LIKE.