### PR TITLE
Manjaro .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -359,7 +359,7 @@ distribution ()
 			gentoo)
 				dtype="gentoo"
 				;;
-			arch)
+			arch|manjaro)
 				dtype="arch"
 				;;
 			slackware)


### PR DESCRIPTION
Line 362, change "arch)" to "arch|manjaro)"  so it identifies manjaro as an arch disto.
  brand-new to git, first ever pull request.  I made this change on my personal system and it worked.