### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -172,7 +172,7 @@ install_additional_dependencies() {
             ;;
         *zypper)
             ${SUDO_CMD} zypper refresh
-            ${SUDO_CMD} zypper install -y neovim 
+            ${SUDO_CMD} zypper -n install neovim # -y doesn't work on opensuse -n is short for -non-interactive which is equivalent to -y
             ;;
         *dnf)
             ${SUDO_CMD} dnf check-update


### PR DESCRIPTION
I just changed zypper  install for neovim . 
I changed  zypper install -y neovim  to zypper -n install neovim
-y  doesn't work on opensuse .
-n is short for --non-interactive and is the equivalent for -y for opensuse.
