### PR TITLE
bashrc fastfetch path dynamic.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -4,8 +4,10 @@ iatest=$(expr index "$-" i)
 #######################################################
 # SOURCED ALIAS'S AND SCRIPTS BY zachbrowne.me
 #######################################################
-if [ -f /usr/bin/fastfetch ]; then
-	fastfetch
+FASTFETCH_PATH=$(which fastfetch 2>/dev/null)
+
+if [ -x "$FASTFETCH_PATH" ]; then
+    "$FASTFETCH_PATH"
 fi
 
 # Source global definitions

--- a/.bashrc
+++ b/.bashrc
@@ -4,10 +4,8 @@ iatest=$(expr index "$-" i)
 #######################################################
 # SOURCED ALIAS'S AND SCRIPTS BY zachbrowne.me
 #######################################################
-FASTFETCH_PATH=$(which fastfetch 2>/dev/null)
-
-if [ -x "$FASTFETCH_PATH" ]; then
-    "$FASTFETCH_PATH"
+if command -v fastfetch 2>/dev/null; then
+    fastfetch
 fi
 
 # Source global definitions


### PR DESCRIPTION
fastfetch's path is found out dynamically running 'which fastfetch' to make the script run for nixos too and others.