### PR TITLE
fix error "flag not found" on tumbleweed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -133,6 +133,8 @@ installDepend() {
         ${SUDO_CMD} ${PACKAGER} -iA nixos.bash nixos.bash-completion nixos.gnutar nixos.neovim nixos.bat nixos.tree nixos.multitail nixos.fastfetch  nixos.pkgs.starship
     elif [ "$PACKAGER" = "dnf" ]; then
         ${SUDO_CMD} ${PACKAGER} install -y ${DEPENDENCIES}
+    elif [ "$PACKAGER" = "zypper" ]; then
+        ${SUDO_CMD} ${PACKAGER} install -n ${DEPENDENCIES}
     else
         ${SUDO_CMD} ${PACKAGER} install -yq ${DEPENDENCIES}
     fi


### PR DESCRIPTION
Fixes the error "Flag -q not found." on openSUSE Tumbleweed.