### PR TITLE
source bash config from existing bash config to make rolling changes easier

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -256,16 +256,14 @@ linkConfig() {
     fi
 
     if cat "$CURRENT_BASHRC" | grep -q ". $GITPATH/.bashrc"; then
-        echo "${YELLOW}New bash config is already being sourced, continuing${RC}"
-        return 0
+        echo "Bash config is already being sourced${RC}"
     else
-        echo "${GREEN}Appending to current bash config${RC}"
+        echo "Appending to current bash config"
         cat >> $CURRENT_BASHRC << EOF
 
-## Source ChrisTitusTech's bash config
+## ChrisTitusTech's bash config
 . $GITPATH/.bashrc
 EOF
-        return $?
     fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -248,25 +248,25 @@ create_fastfetch_config() {
 linkConfig() {
     ## Get the correct user home directory.
     USER_HOME=$(getent passwd "${SUDO_USER:-$USER}" | cut -d: -f6)
-    ## Check if a bashrc file is already there.
-    OLD_BASHRC="$USER_HOME/.bashrc"
-    if [ -e "$OLD_BASHRC" ]; then
-        echo "${YELLOW}Moving old bash config file to $USER_HOME/.bashrc.bak${RC}"
-        if ! mv "$OLD_BASHRC" "$USER_HOME/.bashrc.bak"; then
-            echo "${RED}Can't move the old bash config file!${RC}"
-            exit 1
-        fi
+    ## Make sure a bashrc file is already there.
+    CURRENT_BASHRC="$USER_HOME/.bashrc"
+    if [ ! -e "$CURRENT_BASHRC" ]; then
+        echo "${YELLOW}$CURRENT_BASHRC doesn't exist, creating it${RC}"
+        touch "$CURRENT_BASHRC"
     fi
 
-    echo "${YELLOW}Linking new bash config file...${RC}"
-    ln -svf "$GITPATH/.bashrc" "$USER_HOME/.bashrc" || {
-        echo "${RED}Failed to create symbolic link for .bashrc${RC}"
-        exit 1
-    }
-    ln -svf "$GITPATH/starship.toml" "$USER_HOME/.config/starship.toml" || {
-        echo "${RED}Failed to create symbolic link for starship.toml${RC}"
-        exit 1
-    }
+    if cat "$CURRENT_BASHRC" | grep -q ". $GITPATH/.bashrc"; then
+        echo "${YELLOW}New bash config is already being sourced, continuing${RC}"
+        return 0
+    else
+        echo "${GREEN}Appending to current bash config${RC}"
+        cat >> $CURRENT_BASHRC << EOF
+
+## Source ChrisTitusTech's bash config
+. $GITPATH/.bashrc
+EOF
+        return $?
+    fi
 }
 
 checkEnv


### PR DESCRIPTION
## Changes
- source bash config from this repo from existing bashrc rather than overwriting
- detect if the new bash config is already being sourced, don't append if it's been found

## Rationale
There's been multiple people that have used this bash configuration setup from the [linutil project](https://github.com/ChrisTitusTech/linutil) that have been left without a way to rollback the changes.
### Issues reported:
- ChrisTitusTech/linutil#260
- ChrisTitusTech/linutil#240

Pulling in these changes should make it pretty trivial to revert any modifications to the bash prompt