### PR TITLE
Update pico and nano aliases in .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -64,10 +64,8 @@ if [[ $iatest -gt 0 ]]; then bind "set show-all-if-ambiguous On"; fi
 # Set the default editor
 export EDITOR=nvim
 export VISUAL=nvim
-alias pico='edit'
-alias spico='sedit'
-alias nano='edit'
-alias snano='sedit'
+alias spico='sudo pico'
+alias snano='sudo nano'
 alias vim='nvim'
 
 # To have colors for ls and all grep commands such as grep, egrep and zgrep


### PR DESCRIPTION
Removed aliases for pico and nano since 'edit' is not a valid command. Also, updated spico and snano aliases to run sudo pico and sudo nano respectively.