### PR TITLE
removing '--show-progress' from wget

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -149,7 +149,7 @@ installDepend() {
         # check if the file is accessible
         if wget -q --spider "$FONT_URL"; then
             TEMP_DIR=$(mktemp -d)
-            wget -q --show-progress $FONT_URL -O "$TEMP_DIR"/"${FONT_NAME}".zip
+            wget -q $FONT_URL -O "$TEMP_DIR"/"${FONT_NAME}".zip
             unzip "$TEMP_DIR"/"${FONT_NAME}".zip -d "$TEMP_DIR"
             mkdir -p "$FONT_DIR"/"$FONT_NAME"
             mv "${TEMP_DIR}"/*.ttf "$FONT_DIR"/"$FONT_NAME"


### PR DESCRIPTION
Ran into a small issue with the script running on fedora workstation 40

Wget error:

Unknown option 'show-progress'

Initially updated this to '--force-progress' - but considering how small this is, suggest its easier just to remove the parameter.
