### PR TITLE
.bashrc_fix_whatsmyip_function

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -674,7 +674,8 @@ function whatsmyip() {
 	# External IP Lookup
 	echo -n "External IP: "
 	if command -v curl >/dev/null 2>&1; then
-		curl -4fsS --max-time 5 https://ifconfig.me || echo "unknown"
+		curl -4fsS --max-time 5 https://ifconfig.me || printf '%s' "unknown"
+		echo
 	else
 		echo "curl not installed"
 	fi


### PR DESCRIPTION
Add support to correctly identify actual wlan interface name for whatsmyip function. Where wlan0 was hard coded we now try to identify actual device. On newer Ubuntu installs, the device is usually begins with wlp. If the iw command is not available, we fail back to hard coded wlan0. Also added a carriage return after the command to begin a new line.