### PR TITLE
MyBash V2

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
-iatest=$(expr index "$-" i)
+[[ $- == *i* ]] && iatest=1 || iatest=0
 #######################################################
 # SOURCED ALIAS'S AND SCRIPTS BY zachbrowne.me
 #######################################################
-if [ -f /usr/bin/fastfetch ]; then
+if [[ $iatest -gt 0 ]] && command -v fastfetch >/dev/null 2>&1; then
 	fastfetch
 fi
 
 # Source global definitions
 if [ -f /etc/bashrc ]; then
+	# shellcheck source=/dev/null
 	. /etc/bashrc
 fi
 
 # Enable bash programmable completion features in interactive shells
-if [ -f /usr/share/bash-completion/bash_completion ]; then
+if [[ $iatest -gt 0 ]] && [ -f /usr/share/bash-completion/bash_completion ]; then
+	# shellcheck source=/dev/null
 	. /usr/share/bash-completion/bash_completion
-elif [ -f /etc/bash_completion ]; then
+elif [[ $iatest -gt 0 ]] && [ -f /etc/bash_completion ]; then
+	# shellcheck source=/dev/null
 	. /etc/bash_completion
 fi
 
@@ -39,7 +42,14 @@ shopt -s checkwinsize
 
 # Causes bash to append to history instead of overwriting it so if you start a new terminal, you have old session history
 shopt -s histappend
-PROMPT_COMMAND='history -a'
+_bashrc_history_sync() {
+	history -a
+	history -n
+}
+case ";$PROMPT_COMMAND;" in
+	*";_bashrc_history_sync;"*) ;;
+	*) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}_bashrc_history_sync" ;;
+esac
 
 # set up XDG folders
 export XDG_DATA_HOME="$HOME/.local/share"
@@ -61,11 +71,24 @@ if [[ $iatest -gt 0 ]]; then bind "set completion-ignore-case on"; fi
 if [[ $iatest -gt 0 ]]; then bind "set show-all-if-ambiguous On"; fi
 
 # Set the default editor
-export EDITOR=nvim
-export VISUAL=nvim
-alias spico='sudo pico'
-alias snano='sudo nano'
-alias vim='nvim'
+if command -v nvim >/dev/null 2>&1; then
+	export EDITOR=nvim
+	export VISUAL=nvim
+	alias vim='nvim'
+	alias vi='nvim'
+	alias vis='nvim "+set si"'
+elif command -v vim >/dev/null 2>&1; then
+	export EDITOR=vim
+	export VISUAL=vim
+else
+	export EDITOR=vi
+	export VISUAL=vi
+fi
+command -v pico >/dev/null 2>&1 && alias spico='sudo pico'
+command -v nano >/dev/null 2>&1 && alias snano='sudo nano'
+sedit() {
+	sudo "${SUDO_EDITOR:-${EDITOR:-vi}}" "$@"
+}
 
 # To have colors for ls and all grep commands such as grep, egrep and zgrep
 export CLICOLOR=1
@@ -107,10 +130,18 @@ alias web='cd /var/www/html'
 alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
 
 # Edit this .bashrc file
-alias ebrc='edit ~/.bashrc'
+ebrc() {
+	"${EDITOR:-vi}" "$HOME/.bashrc"
+}
 
 # Show help for this .bashrc file
-alias hlp='less ~/.bashrc_help'
+hlp() {
+	if [ -f "$HOME/.bashrc_help" ]; then
+		less "$HOME/.bashrc_help"
+	else
+		echo "No ~/.bashrc_help file found."
+	fi
+}
 
 # alias to show the date
 alias da='date "+%Y-%m-%d %A %T %Z"'
@@ -118,19 +149,30 @@ alias da='date "+%Y-%m-%d %A %T %Z"'
 # Alias's to modified commands
 alias cp='cp -i'
 alias mv='mv -i'
-alias rm='trash -v'
 alias mkdir='mkdir -p'
 alias ps='ps auxf'
 alias ping='ping -c 10'
 alias less='less -R'
 alias cls='clear'
-alias apt-get='sudo apt-get'
-alias multitail='multitail --no-repeat -c'
-alias freshclam='sudo freshclam'
-alias vi='nvim'
-alias svi='sudo vi'
-alias vis='nvim "+set si"'
-alias yayf="yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75% | xargs -ro yay -S"
+
+if command -v trash-put >/dev/null 2>&1; then
+	alias rm='trash-put'
+elif command -v trash >/dev/null 2>&1; then
+	alias rm='trash -v'
+elif command -v gio >/dev/null 2>&1; then
+	alias rm='gio trash'
+else
+	alias rm='rm -i'
+fi
+
+command -v multitail >/dev/null 2>&1 && alias multitail='multitail --no-repeat -c'
+command -v freshclam >/dev/null 2>&1 && alias freshclam='sudo freshclam'
+svi() {
+	sudo "${EDITOR:-vi}" "$@"
+}
+if command -v yay >/dev/null 2>&1 && command -v fzf >/dev/null 2>&1; then
+	alias yayf="yay -Slq | fzf --multi --preview 'yay -Sii {1}' --preview-window=down:75% | xargs -ro yay -S"
+fi
 
 # Change directory aliases
 alias home='cd ~'
@@ -144,7 +186,7 @@ alias .....='cd ../../../..'
 alias bd='cd "$OLDPWD"'
 
 # Remove a directory and all files
-alias rmd='/bin/rm  --recursive --force --verbose '
+alias rmd='/bin/rm --recursive --force --verbose --one-file-system --'
 
 # Alias's for multiple directory listing commands
 alias la='ls -Alh'                # show hidden files
@@ -159,8 +201,8 @@ alias lm='ls -alh |more'          # pipe through 'more'
 alias lw='ls -xAh'                # wide listing format
 alias ll='ls -Fls'                # long listing format
 alias labc='ls -lap'              # alphabetical sort
-alias lf="ls -l | egrep -v '^d'"  # files only
-alias ldir="ls -l | egrep '^d'"   # directories only
+alias lf="ls -l | grep -Ev '^d'"  # files only
+alias ldir="ls -l | grep -E '^d'" # directories only
 alias lla='ls -Al'                # List and Hidden Files
 alias las='ls -A'                 # Hidden Files
 alias lls='ls -l'                 # List
@@ -184,13 +226,22 @@ alias topcpu="/bin/ps -eo pcpu,pid,user,args | sort -k 1 -r | head -10"
 alias f="find . | grep "
 
 # Count all files (recursively) in the current folder
-alias countfiles="for t in files links directories; do echo \`find . -type \${t:0:1} | wc -l\` \$t; done 2> /dev/null"
+countfiles() {
+	local t
+	for t in files links directories; do
+		echo "$(find . -type "${t:0:1}" | wc -l)" "$t"
+	done 2>/dev/null
+}
 
 # To see if a command is aliased, a file, or a built-in command
 alias checkcommand="type -t"
 
 # Show open ports
-alias openports='netstat -nape --inet'
+if command -v ss >/dev/null 2>&1; then
+	alias openports='ss -tulpen'
+elif command -v netstat >/dev/null 2>&1; then
+	alias openports='netstat -nape --inet'
+fi
 
 # Alias's for safe and forced reboots
 alias rebootsafe='sudo shutdown -r now'
@@ -200,8 +251,8 @@ alias rebootforce='sudo shutdown -r -n now'
 alias diskspace="du -S | sort -n -r |more"
 alias folders='du -h --max-depth=1'
 alias folderssort='find . -maxdepth 1 -type d -print0 | xargs -0 du -sk | sort -rn'
-alias tree='tree -CAhF --dirsfirst'
-alias treed='tree -CAFd'
+command -v tree >/dev/null 2>&1 && alias tree='tree -CAhF --dirsfirst'
+command -v tree >/dev/null 2>&1 && alias treed='tree -CAFd'
 alias mountedinfo='df -hT'
 
 # Alias's for archives
@@ -218,19 +269,34 @@ alias logs="sudo find /var/log -type f -exec file {} \; | grep 'text' | cut -d' 
 # SHA1
 alias sha1='openssl sha1'
 
-alias clickpaste='sleep 3; xdotool type "$(xclip -o -selection clipboard)"'
+clickpaste() {
+	sleep "${1:-3}"
+	if command -v wl-paste >/dev/null 2>&1 && command -v wtype >/dev/null 2>&1; then
+		wl-paste | wtype -
+	elif command -v xclip >/dev/null 2>&1 && command -v xdotool >/dev/null 2>&1; then
+		xdotool type "$(xclip -o -selection clipboard)"
+	else
+		echo "clickpaste requires wl-paste+wtype on Wayland or xclip+xdotool on X11."
+		return 1
+	fi
+}
 
 # KITTY - alias to be able to use kitty features when connecting to remote servers(e.g use tmux on remote server)
 
-alias kssh="kitty +kitten ssh"
+command -v kitty >/dev/null 2>&1 && alias kssh="kitty +kitten ssh"
 
 # alias to cleanup unused docker containers, images, networks, and volumes
 
-alias docker-clean=' \
-  docker container prune -f ; \
-  docker image prune -f ; \
-  docker network prune -f ; \
-  docker volume prune -f '
+docker-clean() {
+	if ! command -v docker >/dev/null 2>&1; then
+		echo "docker is not installed."
+		return 1
+	fi
+	docker container prune -f
+	docker image prune -f
+	docker network prune -f
+	docker volume prune -f
+}
 
 #######################################################
 # SPECIAL FUNCTIONS
@@ -240,17 +306,17 @@ extract() {
 	for archive in "$@"; do
 		if [ -f "$archive" ]; then
 			case $archive in
-			*.tar.bz2) tar xvjf $archive ;;
-			*.tar.gz) tar xvzf $archive ;;
-			*.bz2) bunzip2 $archive ;;
-			*.rar) rar x $archive ;;
-			*.gz) gunzip $archive ;;
-			*.tar) tar xvf $archive ;;
-			*.tbz2) tar xvjf $archive ;;
-			*.tgz) tar xvzf $archive ;;
-			*.zip) unzip $archive ;;
-			*.Z) uncompress $archive ;;
-			*.7z) 7z x $archive ;;
+			*.tar.bz2) tar xvjf "$archive" ;;
+			*.tar.gz) tar xvzf "$archive" ;;
+			*.bz2) bunzip2 "$archive" ;;
+			*.rar) rar x "$archive" ;;
+			*.gz) gunzip "$archive" ;;
+			*.tar) tar xvf "$archive" ;;
+			*.tbz2) tar xvjf "$archive" ;;
+			*.tgz) tar xvzf "$archive" ;;
+			*.zip) unzip "$archive" ;;
+			*.Z) uncompress "$archive" ;;
+			*.7z) 7z x "$archive" ;;
 			*) echo "don't know how to extract '$archive'..." ;;
 			esac
 		else
@@ -273,28 +339,36 @@ ftext() {
 
 # Copy file with a progress bar
 cpp() {
-    set -e
-    strace -q -ewrite cp -- "${1}" "${2}" 2>&1 |
-    awk '{
-        count += $NF
-        if (count % 10 == 0) {
-            percent = count / total_size * 100
-            printf "%3d%% [", percent
-            for (i=0;i<=percent;i++)
-                printf "="
-            printf ">"
-            for (i=percent;i<100;i++)
-                printf " "
-            printf "]\r"
-        }
-    }
-    END { print "" }' total_size="$(stat -c '%s' "${1}")" count=0
+	if [ "$#" -ne 2 ]; then
+		echo "Usage: cpp SOURCE DESTINATION"
+		return 2
+	fi
+	if ! command -v strace >/dev/null 2>&1; then
+		echo "cpp requires strace."
+		return 1
+	fi
+	strace -q -ewrite cp -- "$1" "$2" 2>&1 |
+	awk '{
+		count += $NF
+		if (count % 10 == 0 && total_size > 0) {
+			percent = int(count / total_size * 100)
+			if (percent > 100) percent = 100
+			printf "%3d%% [", percent
+			for (i=0;i<=percent;i++)
+				printf "="
+			printf ">"
+			for (i=percent;i<100;i++)
+				printf " "
+			printf "]\r"
+		}
+	}
+	END { print "" }' total_size="$(stat -c '%s' "$1")" count=0
 }
 
 # Copy and go to the directory
 cpg() {
 	if [ -d "$2" ]; then
-		cp "$1" "$2" && cd "$2"
+		cp "$1" "$2" && cd "$2" || return
 	else
 		cp "$1" "$2"
 	fi
@@ -303,7 +377,7 @@ cpg() {
 # Move and go to the directory
 mvg() {
 	if [ -d "$2" ]; then
-		mv "$1" "$2" && cd "$2"
+		mv "$1" "$2" && cd "$2" || return
 	else
 		mv "$1" "$2"
 	fi
@@ -311,22 +385,25 @@ mvg() {
 
 # Create and go to the directory
 mkdirg() {
-	mkdir -p "$1"
-	cd "$1"
+	mkdir -p "$1" && cd "$1" || return
 }
 
 # Goes up a specified number of directories  (i.e. up 4)
 up() {
-	local d=""
-	limit=$1
+	local d="" limit i
+	limit=${1:-1}
+	if ! [[ $limit =~ ^[0-9]+$ ]]; then
+		echo "Usage: up [number]"
+		return 2
+	fi
 	for ((i = 1; i <= limit; i++)); do
 		d=$d/..
 	done
-	d=$(echo $d | sed 's/^\///')
+	d=$(echo "$d" | sed 's/^\///')
 	if [ -z "$d" ]; then
 		d=..
 	fi
-	cd $d
+	cd "$d" || return
 }
 
 # Automatically do an ls after each cd, z, or zoxide
@@ -350,6 +427,7 @@ distribution () {
 
     # Use /etc/os-release for modern distro identification
     if [ -r /etc/os-release ]; then
+        # shellcheck source=/dev/null
         source /etc/os-release
         case $ID in
             fedora|rhel|centos)
@@ -403,9 +481,6 @@ distribution () {
     echo $dtype
 }
 
-
-DISTRIBUTION=$(distribution)
-
 # Show the current version of the operating system
 ver() {
     local dtype
@@ -453,24 +528,21 @@ install_bashrc_support() {
 
 	case $dtype in
 		"redhat")
-			sudo yum install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+			if command -v dnf >/dev/null 2>&1; then
+				sudo dnf install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+			else
+				sudo yum install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+			fi
 			;;
 		"suse")
 			sudo zypper install multitail tree zoxide trash-cli fzf bash-completion fastfetch
 			;;
 		"debian")
-			sudo apt-get install multitail tree zoxide trash-cli fzf bash-completion
-			# Fetch the latest fastfetch release URL for linux-amd64 deb file
-			FASTFETCH_URL=$(curl -s https://api.github.com/repos/fastfetch-cli/fastfetch/releases/latest | grep "browser_download_url.*linux-amd64.deb" | cut -d '"' -f 4)
-
-			# Download the latest fastfetch deb file
-			curl -sL $FASTFETCH_URL -o /tmp/fastfetch_latest_amd64.deb
-
-			# Install the downloaded deb file using apt-get
-			sudo apt-get install /tmp/fastfetch_latest_amd64.deb
+			sudo apt-get update
+			sudo apt-get install multitail tree zoxide trash-cli fzf bash-completion fastfetch
 			;;
 		"arch")
-			sudo paru multitail tree zoxide trash-cli fzf bash-completion fastfetch
+			sudo pacman -S --needed multitail tree zoxide trash-cli fzf bash-completion fastfetch
 			;;
 		"slackware")
 			echo "No install support for Slackware"
@@ -484,30 +556,55 @@ install_bashrc_support() {
 # IP address lookup
 alias whatismyip="whatsmyip"
 function whatsmyip () {
-    # Internal IP Lookup.
-    if command -v ip &> /dev/null; then
-        echo -n "Internal IP: "
-        ip addr show wlan0 | grep "inet " | awk '{print $2}' | cut -d/ -f1
-    else
-        echo -n "Internal IP: "
-        ifconfig wlan0 | grep "inet " | awk '{print $2}'
-    fi
+	# Internal IP Lookup.
+	echo -n "Internal IP: "
+	if command -v ip >/dev/null 2>&1; then
+		ip -o -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1; i<=NF; i++) if ($i == "src") {print $(i+1); exit}}'
+	elif command -v ifconfig >/dev/null 2>&1; then
+		ifconfig | awk '/inet / && $2 != "127.0.0.1" {print $2; exit}'
+	else
+		echo "unknown"
+	fi
 
-    # External IP Lookup
-    echo -n "External IP: "
-    curl -4 ifconfig.me
+	# External IP Lookup
+	echo -n "External IP: "
+	if command -v curl >/dev/null 2>&1; then
+		curl -4fsS --max-time 5 https://ifconfig.me || echo "unknown"
+	else
+		echo "curl not installed"
+	fi
 }
 
 # View Apache logs
 apachelog() {
 	if [ -f /etc/httpd/conf/httpd.conf ]; then
-		cd /var/log/httpd && ls -xAh && multitail --no-repeat -c -s 2 /var/log/httpd/*_log
+		cd /var/log/httpd && ls -xAh || return
+		if command -v multitail >/dev/null 2>&1; then
+			multitail --no-repeat -c -s 2 /var/log/httpd/*_log
+		else
+			tail -f /var/log/httpd/*_log
+		fi
+	elif [ -d /var/log/apache2 ]; then
+		cd /var/log/apache2 && ls -xAh || return
+		if command -v multitail >/dev/null 2>&1; then
+			multitail --no-repeat -c -s 2 /var/log/apache2/*.log
+		else
+			tail -f /var/log/apache2/*.log
+		fi
 	else
-		cd /var/log/apache2 && ls -xAh && multitail --no-repeat -c -s 2 /var/log/apache2/*.log
+		echo "Error: Apache log directory could not be found."
 	fi
 }
 
-# Edit the Apache configuration
+find_config_file() {
+	local name=$1
+	if command -v locate >/dev/null 2>&1; then
+		sudo updatedb && locate "$name"
+	else
+		echo "locate is not installed."
+	fi
+}
+
 apacheconfig() {
 	if [ -f /etc/httpd/conf/httpd.conf ]; then
 		sedit /etc/httpd/conf/httpd.conf
@@ -516,7 +613,8 @@ apacheconfig() {
 	else
 		echo "Error: Apache config file could not be found."
 		echo "Searching for possible locations:"
-		sudo updatedb && locate httpd.conf && locate apache2.conf
+		find_config_file httpd.conf
+		find_config_file apache2.conf
 	fi
 }
 
@@ -535,7 +633,7 @@ phpconfig() {
 	else
 		echo "Error: php.ini file could not be found."
 		echo "Searching for possible locations:"
-		sudo updatedb && locate php.ini
+		find_config_file php.ini
 	fi
 }
 
@@ -549,14 +647,14 @@ mysqlconfig() {
 		sedit /usr/local/etc/my.cnf
 	elif [ -f /usr/bin/mysql/my.cnf ]; then
 		sedit /usr/bin/mysql/my.cnf
-	elif [ -f ~/my.cnf ]; then
-		sedit ~/my.cnf
-	elif [ -f ~/.my.cnf ]; then
-		sedit ~/.my.cnf
+	elif [ -f "$HOME/my.cnf" ]; then
+		sedit "$HOME/my.cnf"
+	elif [ -f "$HOME/.my.cnf" ]; then
+		sedit "$HOME/.my.cnf"
 	else
 		echo "Error: my.cnf file could not be found."
 		echo "Searching for possible locations:"
-		sudo updatedb && locate my.cnf
+		find_config_file my.cnf
 	fi
 }
 
@@ -571,10 +669,18 @@ trim() {
 # GitHub Titus Additions
 
 gcom() {
+	if [ -z "$1" ]; then
+		echo "Usage: gcom \"commit message\""
+		return 2
+	fi
 	git add .
 	git commit -m "$1"
 }
 lazyg() {
+	if [ -z "$1" ]; then
+		echo "Usage: lazyg \"commit message\""
+		return 2
+	fi
 	git add .
 	git commit -m "$1"
 	git push
@@ -584,11 +690,13 @@ lazyg() {
 # Set the ultimate amazing command prompt
 #######################################################
 
-alias hug="systemctl --user restart hugo"
-alias lanm="systemctl --user restart lan-mouse"
+if command -v systemctl >/dev/null 2>&1; then
+	alias hug="systemctl --user restart hugo"
+	alias lanm="systemctl --user restart lan-mouse"
+fi
 
 # Check if the shell is interactive
-if [[ $- == *i* ]]; then
+if [[ $- == *i* ]] && command -v zoxide >/dev/null 2>&1; then
     # Bind Ctrl+f to insert 'zi' followed by a newline
     bind '"\C-f":"zi\n"'
 fi
@@ -619,12 +727,16 @@ path_add_first \
 	"$HOME/.deno/bin" \
 	"$HOME/.cargo/bin" \
 	"/var/lib/flatpak/exports/bin" \
-	"/.local/share/flatpak/exports/bin"
+	"$HOME/.local/share/flatpak/exports/bin"
 
 export PATH
 
 
 
 
-eval "$(starship init bash)"
-eval "$(zoxide init bash)"
+if [[ $- == *i* ]] && command -v starship >/dev/null 2>&1; then
+	eval "$(starship init bash)"
+fi
+if [[ $- == *i* ]] && command -v zoxide >/dev/null 2>&1; then
+	eval "$(zoxide init bash)"
+fi


### PR DESCRIPTION
## Type of Change
- [X] Code cleanup / Maintenance

## Summary

Modernizes `.bashrc` while preserving the original “portable Linux toolbox” style. The changes focus on safer defaults, better portability across distros/shell environments, dependency-aware aliases, and ShellCheck-clean behavior.

## What Changed

- Guarded optional tools before use, including `fastfetch`, `tree`, `kitty`, `docker`, `yay`, `fzf`, `starship`, and `zoxide`.
- Improved history handling so `PROMPT_COMMAND` is extended instead of overwritten.
- Added editor fallback logic: `nvim` -> `vim` -> `vi`.
- Added `sedit()` for sudo editing through `$SUDO_EDITOR` or `$EDITOR`.
- Made `rm` safer with fallbacks: `trash-put`, `trash`, `gio trash`, then `rm -i`.
- Replaced deprecated `egrep` usage with `grep -E`.
- Replaced `netstat`-first open port lookup with `ss`-first behavior.
- Converted fragile aliases like `countfiles`, `clickpaste`, and `docker-clean` into functions.
- Quoted archive extraction paths to support filenames with spaces/special characters.
- Improved helper function error handling for `cpp`, `cpg`, `mvg`, `mkdirg`, and `up`.
- Modernized distro package install logic and removed fragile external release scraping:
  - Prefer `dnf` over `yum` when available.
  - Use `apt-get` packages directly instead of scraping GitHub for fastfetch.
  - Use `pacman -S --needed` for Arch instead of assuming `paru`.
- Improved IP lookup so it does not hard-code `wlan0`.
- Added safer Apache/PHP/MySQL config lookup helpers.
- Added commit message validation to `gcom` and `lazyg`.
- Fixed the Flatpak user export path from `/.local/...` to `$HOME/.local/...`
- Added ShellCheck source annotations for system files.

