### PR TITLE
Add macOS Bash 5 installer support

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -7,6 +7,23 @@ if [[ $iatest -gt 0 ]] && command -v fastfetch >/dev/null 2>&1; then
 	fastfetch
 fi
 
+_bashrc_os=$(uname -s 2>/dev/null || echo unknown)
+
+if [ "$_bashrc_os" = "Darwin" ]; then
+	for _bashrc_path_entry in \
+		/usr/local/sbin \
+		/usr/local/bin \
+		/opt/homebrew/sbin \
+		/opt/homebrew/bin \
+		/opt/homebrew/opt/trash/bin; do
+		if [ -d "$_bashrc_path_entry" ]; then
+			PATH="$_bashrc_path_entry:$PATH"
+		fi
+	done
+	unset _bashrc_path_entry
+	export PATH
+fi
+
 # Source global definitions
 if [ -f /etc/bashrc ]; then
 	# shellcheck source=/dev/null
@@ -14,12 +31,25 @@ if [ -f /etc/bashrc ]; then
 fi
 
 # Enable bash programmable completion features in interactive shells
-if [[ $iatest -gt 0 ]] && [ -f /usr/share/bash-completion/bash_completion ]; then
-	# shellcheck source=/dev/null
-	. /usr/share/bash-completion/bash_completion
-elif [[ $iatest -gt 0 ]] && [ -f /etc/bash_completion ]; then
-	# shellcheck source=/dev/null
-	. /etc/bash_completion
+if [[ $iatest -gt 0 ]]; then
+	for _bash_completion in \
+		/opt/homebrew/etc/profile.d/bash_completion.sh \
+		/usr/local/etc/profile.d/bash_completion.sh \
+		/usr/share/bash-completion/bash_completion \
+		/etc/bash_completion; do
+		if [ -f "$_bash_completion" ]; then
+			if [ "$_bashrc_os" = "Darwin" ] && [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+				_bashrc_completion_dir="$HOME/.cache/mybash/bash_completion.d"
+				mkdir -p "$_bashrc_completion_dir"
+				export BASH_COMPLETION_DIR="$_bashrc_completion_dir"
+				export BASH_COMPLETION_COMPAT_DIR="$_bashrc_completion_dir"
+			fi
+			# shellcheck source=/dev/null
+			. "$_bash_completion"
+			break
+		fi
+	done
+	unset _bash_completion _bashrc_completion_dir
 fi
 
 #######################################################
@@ -47,8 +77,8 @@ _bashrc_history_sync() {
 	history -n
 }
 case ";$PROMPT_COMMAND;" in
-	*";_bashrc_history_sync;"*) ;;
-	*) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}_bashrc_history_sync" ;;
+*";_bashrc_history_sync;"*) ;;
+*) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}_bashrc_history_sync" ;;
 esac
 
 # set up XDG folders
@@ -58,10 +88,10 @@ export XDG_STATE_HOME="$HOME/.local/state"
 export XDG_CACHE_HOME="$HOME/.cache"
 
 # Seeing as other scripts will use it might as well export it
-export LINUXTOOLBOXDIR="$HOME/linuxtoolbox"
+export MYBASHDIR="$HOME/.local/share/mybash"
 
 # Allow ctrl-S for history navigation (with ctrl-R)
-[[ $- == *i* ]] && stty -ixon
+[[ $- == *i* ]] && [ -t 0 ] && stty -ixon
 
 # Ignore case on auto-completion
 # Note: bind used instead of sticking these in .inputrc
@@ -127,7 +157,35 @@ alias web='cd /var/www/html'
 
 # Add an "alert" alias for long running commands.  Use like so:
 #   sleep 10; alert
-alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+alert() {
+	local exit_status=$? icon last_command title
+	if [ "$exit_status" -eq 0 ]; then
+		icon=terminal
+		title=Done
+	else
+		icon=error
+		title=Failed
+	fi
+	last_command=$(history 1 | sed -e 's/^[[:space:]]*[0-9]\+[[:space:]]*//;s/[;&|][[:space:]]*alert$//')
+
+	case $_bashrc_os in
+	Darwin)
+		if command -v osascript >/dev/null 2>&1; then
+			MYBASH_ALERT_MESSAGE=$last_command MYBASH_ALERT_TITLE=$title \
+				osascript -e 'display notification (system attribute "MYBASH_ALERT_MESSAGE") with title (system attribute "MYBASH_ALERT_TITLE")'
+		else
+			printf '%s: %s\n' "$title" "$last_command"
+		fi
+		;;
+	*)
+		if command -v notify-send >/dev/null 2>&1; then
+			notify-send --urgency=low -i "$icon" "$last_command"
+		else
+			printf '%s: %s\n' "$title" "$last_command"
+		fi
+		;;
+	esac
+}
 
 # Edit this .bashrc file
 ebrc() {
@@ -150,7 +208,11 @@ alias da='date "+%Y-%m-%d %A %T %Z"'
 alias cp='cp -i'
 alias mv='mv -i'
 alias mkdir='mkdir -p'
-alias ps='ps auxf'
+if ps auxf >/dev/null 2>&1; then
+	alias ps='ps auxf'
+else
+	alias ps='ps aux'
+fi
 alias ping='ping -c 10'
 alias less='less -R'
 alias cls='clear'
@@ -186,11 +248,19 @@ alias .....='cd ../../../..'
 alias bd='cd "$OLDPWD"'
 
 # Remove a directory and all files
-alias rmd='/bin/rm --recursive --force --verbose --one-file-system --'
+if /bin/rm --recursive --force --verbose --one-file-system -- /tmp/.bashrc-rm-test-noop >/dev/null 2>&1; then
+	alias rmd='/bin/rm --recursive --force --verbose --one-file-system --'
+else
+	alias rmd='/bin/rm -rfv --'
+fi
 
 # Alias's for multiple directory listing commands
-alias la='ls -Alh'                # show hidden files
-alias ls='ls -aFh --color=always' # add colors and file type extensions
+alias la='ls -Alh' # show hidden files
+if ls -d --color=always . >/dev/null 2>&1; then
+	alias ls='ls -aFh --color=always' # add colors and file type extensions
+else
+	alias ls='ls -aFhG' # add colors and file type extensions on BSD/macOS
+fi
 alias lx='ls -lXBh'               # sort by extension
 alias lk='ls -lSrh'               # sort by size
 alias lc='ls -ltcrh'              # sort by change time
@@ -240,7 +310,11 @@ alias checkcommand="type -t"
 if command -v ss >/dev/null 2>&1; then
 	alias openports='ss -tulpen'
 elif command -v netstat >/dev/null 2>&1; then
-	alias openports='netstat -nape --inet'
+	if netstat -nape --inet >/dev/null 2>&1; then
+		alias openports='netstat -nape --inet'
+	else
+		alias openports='netstat -anv'
+	fi
 fi
 
 # Alias's for safe and forced reboots
@@ -249,11 +323,19 @@ alias rebootforce='sudo shutdown -r -n now'
 
 # Alias's to show disk space and space used in a folder
 alias diskspace="du -S | sort -n -r |more"
-alias folders='du -h --max-depth=1'
+if du -h --max-depth=1 . >/dev/null 2>&1; then
+	alias folders='du -h --max-depth=1'
+else
+	alias folders='du -hd 1'
+fi
 alias folderssort='find . -maxdepth 1 -type d -print0 | xargs -0 du -sk | sort -rn'
 command -v tree >/dev/null 2>&1 && alias tree='tree -CAhF --dirsfirst'
 command -v tree >/dev/null 2>&1 && alias treed='tree -CAFd'
-alias mountedinfo='df -hT'
+if df -hT . >/dev/null 2>&1; then
+	alias mountedinfo='df -hT'
+else
+	alias mountedinfo='df -h'
+fi
 
 # Alias's for archives
 alias mktar='tar -cvf'
@@ -337,6 +419,14 @@ ftext() {
 	grep -iIHrn --color=always "$1" . | less -r
 }
 
+_bashrc_file_size() {
+	if stat -c '%s' "$1" >/dev/null 2>&1; then
+		stat -c '%s' "$1"
+	else
+		stat -f '%z' "$1"
+	fi
+}
+
 # Copy file with a progress bar
 cpp() {
 	if [ "$#" -ne 2 ]; then
@@ -348,7 +438,7 @@ cpp() {
 		return 1
 	fi
 	strace -q -ewrite cp -- "$1" "$2" 2>&1 |
-	awk '{
+		awk '{
 		count += $NF
 		if (count % 10 == 0 && total_size > 0) {
 			percent = int(count / total_size * 100)
@@ -362,7 +452,7 @@ cpp() {
 			printf "]\r"
 		}
 	}
-	END { print "" }' total_size="$(stat -c '%s' "$1")" count=0
+	END { print "" }' total_size="$(_bashrc_file_size "$1")" count=0
 }
 
 # Copy and go to the directory
@@ -407,8 +497,7 @@ up() {
 }
 
 # Automatically do an ls after each cd, z, or zoxide
-cd ()
-{
+cd() {
 	if [ -n "$1" ]; then
 		builtin cd "$@" && ls
 	else
@@ -422,103 +511,111 @@ pwdtail() {
 }
 
 # Show the current distribution
-distribution () {
-    local dtype="unknown"  # Default to unknown
+distribution() {
+	local dtype="unknown" # Default to unknown
 
-    # Use /etc/os-release for modern distro identification
-    if [ -r /etc/os-release ]; then
-        # shellcheck source=/dev/null
-        source /etc/os-release
-        case $ID in
-            fedora|rhel|centos)
-                dtype="redhat"
-                ;;
-            sles|opensuse*)
-                dtype="suse"
-                ;;
-            ubuntu|debian)
-                dtype="debian"
-                ;;
-            gentoo)
-                dtype="gentoo"
-                ;;
-            arch|manjaro)
-                dtype="arch"
-                ;;
-            slackware)
-                dtype="slackware"
-                ;;
-            *)
-                # Check ID_LIKE only if dtype is still unknown
-                if [ -n "$ID_LIKE" ]; then
-                    case $ID_LIKE in
-                        *fedora*|*rhel*|*centos*)
-                            dtype="redhat"
-                            ;;
-                        *sles*|*opensuse*)
-                            dtype="suse"
-                            ;;
-                        *ubuntu*|*debian*)
-                            dtype="debian"
-                            ;;
-                        *gentoo*)
-                            dtype="gentoo"
-                            ;;
-                        *arch*)
-                            dtype="arch"
-                            ;;
-                        *slackware*)
-                            dtype="slackware"
-                            ;;
-                    esac
-                fi
+	case $_bashrc_os in
+	Darwin)
+		dtype="macos"
+		;;
+	Linux)
+		# Use /etc/os-release for modern distro identification
+		if [ -r /etc/os-release ]; then
+			# shellcheck source=/dev/null
+			source /etc/os-release
+			case $ID in
+			fedora | rhel | centos)
+				dtype="redhat"
+				;;
+			sles | opensuse*)
+				dtype="suse"
+				;;
+			ubuntu | debian)
+				dtype="debian"
+				;;
+			gentoo)
+				dtype="gentoo"
+				;;
+			arch | manjaro)
+				dtype="arch"
+				;;
+			slackware)
+				dtype="slackware"
+				;;
+			*)
+				if [ -n "$ID_LIKE" ]; then
+					case $ID_LIKE in
+					*fedora* | *rhel* | *centos*)
+						dtype="redhat"
+						;;
+					*sles* | *opensuse*)
+						dtype="suse"
+						;;
+					*ubuntu* | *debian*)
+						dtype="debian"
+						;;
+					*gentoo*)
+						dtype="gentoo"
+						;;
+					*arch*)
+						dtype="arch"
+						;;
+					*slackware*)
+						dtype="slackware"
+						;;
+					esac
+				fi
+				;;
+			esac
+		fi
+		;;
+	esac
 
-                # If ID or ID_LIKE is not recognized, keep dtype as unknown
-                ;;
-        esac
-    fi
-
-    echo $dtype
+	echo "$dtype"
 }
 
 # Show the current version of the operating system
 ver() {
-    local dtype
-    dtype=$(distribution)
+	local dtype
+	dtype=$(distribution)
 
-    case $dtype in
-        "redhat")
-            if [ -s /etc/redhat-release ]; then
-                cat /etc/redhat-release
-            else
-                cat /etc/issue
-            fi
-            uname -a
-            ;;
-        "suse")
-            cat /etc/SuSE-release
-            ;;
-        "debian")
-            lsb_release -a
-            ;;
-        "gentoo")
-            cat /etc/gentoo-release
-            ;;
-        "arch")
-            cat /etc/os-release
-            ;;
-        "slackware")
-            cat /etc/slackware-version
-            ;;
-        *)
-            if [ -s /etc/issue ]; then
-                cat /etc/issue
-            else
-                echo "Error: Unknown distribution"
-                exit 1
-            fi
-            ;;
-    esac
+	case $dtype in
+	"macos")
+		sw_vers
+		uname -a
+		;;
+	"redhat")
+		if [ -s /etc/redhat-release ]; then
+			cat /etc/redhat-release
+		else
+			cat /etc/issue
+		fi
+		uname -a
+		;;
+	"suse")
+		cat /etc/SuSE-release
+		;;
+	"debian")
+		lsb_release -a
+		;;
+	"gentoo")
+		cat /etc/gentoo-release
+		;;
+	"arch")
+		cat /etc/os-release
+		;;
+	"slackware")
+		cat /etc/slackware-version
+		;;
+	*)
+		if [ -s /etc/issue ]; then
+			cat /etc/issue
+		else
+			echo "Error: Unknown distribution"
+			return 1
+		fi
+		;;
+	esac
 }
 
 # Automatically install the needed support files for this .bashrc file
@@ -527,35 +624,43 @@ install_bashrc_support() {
 	dtype=$(distribution)
 
 	case $dtype in
-		"redhat")
-			if command -v dnf >/dev/null 2>&1; then
-				sudo dnf install multitail tree zoxide trash-cli fzf bash-completion fastfetch
-			else
-				sudo yum install multitail tree zoxide trash-cli fzf bash-completion fastfetch
-			fi
-			;;
-		"suse")
-			sudo zypper install multitail tree zoxide trash-cli fzf bash-completion fastfetch
-			;;
-		"debian")
-			sudo apt-get update
-			sudo apt-get install multitail tree zoxide trash-cli fzf bash-completion fastfetch
-			;;
-		"arch")
-			sudo pacman -S --needed multitail tree zoxide trash-cli fzf bash-completion fastfetch
-			;;
-		"slackware")
-			echo "No install support for Slackware"
-			;;
-		*)
-			echo "Unknown distribution"
-			;;
+	"macos")
+		if command -v brew >/dev/null 2>&1; then
+			brew install multitail tree zoxide trash fzf bash-completion fastfetch
+		else
+			echo "Homebrew is required to install support packages on macOS."
+			return 1
+		fi
+		;;
+	"redhat")
+		if command -v dnf >/dev/null 2>&1; then
+			sudo dnf install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+		else
+			sudo yum install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+		fi
+		;;
+	"suse")
+		sudo zypper install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+		;;
+	"debian")
+		sudo apt-get update
+		sudo apt-get install multitail tree zoxide trash-cli fzf bash-completion fastfetch
+		;;
+	"arch")
+		sudo pacman -S --needed multitail tree zoxide trash-cli fzf bash-completion fastfetch
+		;;
+	"slackware")
+		echo "No install support for Slackware"
+		;;
+	*)
+		echo "Unknown distribution"
+		;;
 	esac
 }
 
 # IP address lookup
 alias whatismyip="whatsmyip"
-function whatsmyip () {
+function whatsmyip() {
 	# Internal IP Lookup.
 	echo -n "Internal IP: "
 	if command -v ip >/dev/null 2>&1; then
@@ -658,7 +763,6 @@ mysqlconfig() {
 	fi
 }
 
-
 # Trim leading and trailing spaces (for scripts)
 trim() {
 	local var=$*
@@ -697,8 +801,8 @@ fi
 
 # Check if the shell is interactive
 if [[ $- == *i* ]] && command -v zoxide >/dev/null 2>&1; then
-    # Bind Ctrl+f to insert 'zi' followed by a newline
-    bind '"\C-f":"zi\n"'
+	# Bind Ctrl+f to insert 'zi' followed by a newline
+	bind '"\C-f":"zi\n"'
 fi
 
 path_add_first() {
@@ -706,8 +810,8 @@ path_add_first() {
 	for path_entry in "$@"; do
 		if [ -d "$path_entry" ]; then
 			case ":$PATH:" in
-				*":$path_entry:"*) ;;
-				*) PATH="$path_entry:$PATH" ;;
+			*":$path_entry:"*) ;;
+			*) PATH="$path_entry:$PATH" ;;
 			esac
 		fi
 	done
@@ -729,10 +833,16 @@ path_add_first \
 	"/var/lib/flatpak/exports/bin" \
 	"$HOME/.local/share/flatpak/exports/bin"
 
+if [ "$_bashrc_os" = "Darwin" ]; then
+	path_add_first \
+		"/opt/homebrew/opt/trash/bin" \
+		"/opt/homebrew/bin" \
+		"/opt/homebrew/sbin" \
+		"/usr/local/bin" \
+		"/usr/local/sbin"
+fi
+
 export PATH
-
-
-
 
 if [[ $- == *i* ]] && command -v starship >/dev/null 2>&1; then
 	eval "$(starship init bash)"

--- a/README.md
+++ b/README.md
@@ -29,14 +29,27 @@ cd mybash
 
 The `setup.sh` script automates the installation process by:
 
-- Creating necessary directories (`linuxtoolbox/mybash`)
-- Cloning the repository
+- Creating necessary directories (`~/.local/share/mybash`, `~/.config/starship`, and `~/.config/fastfetch`)
+- Copying the managed repository files into `~/.local/share/mybash`
+- Installing Homebrew on macOS if it is not already installed
+- Installing Bash 5 with Homebrew on macOS
+- Adding Homebrew Bash to `/etc/shells` and setting it as the default login shell on macOS
 - Installing dependencies (bash-completion, neovim, starship, fzf, zoxide)
-- Installing the MesloLGS Nerd Font required for the prompt
-- Linking configuration files (`.bashrc` and `starship.toml`) to your home directory
+- Installing the MesloLGS Nerd Font required for the prompt when available
+- Linking configuration files from `~/.local/share/mybash` to your home directory
+- Linking the fastfetch config to `~/.config/fastfetch/config.jsonc`
+- Ensuring `~/.bash_profile` initializes Homebrew on macOS
+- Ensuring `~/.bash_profile` sources `~/.bashrc` on macOS
 - Setting up additional utilities like `fastfetch`
 
-Ensure you have the required permissions and a supported package manager before running the script.
+On macOS, `setup.sh` may prompt for your password when it adds Homebrew Bash to `/etc/shells` and changes your default shell. Restart Terminal after installation, then verify with:
+
+```sh
+echo "$SHELL"
+bash --version
+```
+
+`$SHELL` should point to the Homebrew Bash path, such as `/opt/homebrew/bin/bash` on Apple Silicon or `/usr/local/bin/bash` on Intel Macs. On Linux, ensure you have the required permissions and a supported package manager.
 
 ## Uninstallation
 
@@ -53,7 +66,7 @@ The `uninstall.sh` script reverses the installation process by:
 - Removing installed dependencies
 - Uninstalling fonts
 - Removing symbolic links to configuration files
-- Deleting the `linuxtoolbox` directory
+- Deleting the `~/.local/share/mybash` directory
 - Cleaning up additional utilities like `starship`, `fzf`, and `zoxide`
 
 After running the script, it's recommended to restart your shell to apply the changes.

--- a/config.jsonc
+++ b/config.jsonc
@@ -30,7 +30,7 @@
     "type": "command",
     "key": "│ ├",
     "keyColor": "yellow",
-    "text": "birth_install=$(stat -c %W /); current=$(date +%s); time_progression=$((current - birth_install)); days_difference=$((time_progression / 86400)); echo $days_difference days"
+    "text": "birth_install=$(stat -c %W / 2>/dev/null || stat -f %B / 2>/dev/null || echo 0); case $birth_install in ''|0|-1) echo unknown;; *) current=$(date +%s); time_progression=$((current - birth_install)); days_difference=$((time_progression / 86400)); echo $days_difference days;; esac"
     },
     {
     "type": "shell",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,266 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(unset CDPATH && cd -- "$(dirname -- "$0")" && pwd -P)
+OS_NAME=$(uname -s 2>/dev/null || echo unknown)
+MYBASHDIR="$HOME/.local/share/mybash"
+
+if command -v tput >/dev/null 2>&1 && [ -t 1 ]; then
+	RC=$(tput sgr0)
+	RED=$(tput setaf 1)
+	YELLOW=$(tput setaf 3)
+	GREEN=$(tput setaf 2)
+else
+	RC=
+	RED=
+	YELLOW=
+	GREEN=
+fi
+
+print_colored() {
+	color=$1
+	message=$2
+	printf '%s%s%s\n' "$color" "$message" "$RC"
+}
+
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+find_brew() {
+	if command_exists brew; then
+		command -v brew
+	elif [ -x /opt/homebrew/bin/brew ]; then
+		printf '%s\n' /opt/homebrew/bin/brew
+	elif [ -x /usr/local/bin/brew ]; then
+		printf '%s\n' /usr/local/bin/brew
+	else
+		return 1
+	fi
+}
+
+sudo_cmd() {
+	if command_exists sudo; then
+		sudo "$@"
+	elif command_exists doas && [ -f /etc/doas.conf ]; then
+		doas "$@"
+	else
+		su -c "$*"
+	fi
+}
+
+ensure_homebrew_macos() {
+	brew_path=$(find_brew 2>/dev/null || true)
+	if [ -z "$brew_path" ]; then
+		if ! command_exists curl; then
+			print_colored "$RED" "curl is required to install Homebrew on macOS."
+			return 1
+		fi
+
+		print_colored "$YELLOW" "Installing Homebrew..."
+		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+		brew_path=$(find_brew 2>/dev/null || true)
+	fi
+
+	if [ -z "$brew_path" ]; then
+		print_colored "$RED" "Homebrew installation finished, but brew was not found."
+		return 1
+	fi
+
+	brew_prefix=$("$brew_path" --prefix)
+	PATH="$brew_prefix/bin:$brew_prefix/sbin:$PATH"
+	export PATH
+	hash -r 2>/dev/null || true
+}
+
+brew_install_missing() {
+	missing=
+	for formula in "$@"; do
+		if ! brew list --formula "$formula" >/dev/null 2>&1; then
+			missing="${missing:+$missing }$formula"
+		fi
+	done
+
+	if [ -n "$missing" ]; then
+		# shellcheck disable=SC2086
+		brew install $missing
+	fi
+}
+
+brew_install_cask_if_available() {
+	cask=$1
+	if brew info --cask "$cask" >/dev/null 2>&1 &&
+		! brew list --cask "$cask" >/dev/null 2>&1; then
+		brew install --cask "$cask"
+	fi
+}
+
+prepare_bash_completion_macos() {
+	if brew list --formula bash-completion >/dev/null 2>&1 &&
+		! brew list --formula bash-completion@2 >/dev/null 2>&1; then
+		print_colored "$YELLOW" "Unlinking bash-completion 1.x before installing bash-completion@2..."
+		brew unlink bash-completion
+	fi
+}
+
+install_dependencies_macos() {
+	ensure_homebrew_macos
+
+	print_colored "$YELLOW" "Installing macOS dependencies with Homebrew..."
+	prepare_bash_completion_macos
+	brew_install_missing bash bash-completion@2 bat tree multitail fastfetch neovim trash fzf zoxide starship
+	brew_install_cask_if_available font-meslo-lg-nerd-font
+}
+
+ensure_homebrew_bash_macos() {
+	[ "$OS_NAME" = Darwin ] || return 0
+
+	ensure_homebrew_macos
+	brew_prefix=$(brew --prefix)
+	brew_bash="$brew_prefix/bin/bash"
+
+	if [ ! -x "$brew_bash" ]; then
+		print_colored "$RED" "Homebrew Bash was not found at $brew_bash."
+		return 1
+	fi
+
+	if ! grep -qxF "$brew_bash" /etc/shells; then
+		print_colored "$YELLOW" "Adding $brew_bash to /etc/shells..."
+		printf '%s\n' "$brew_bash" | sudo tee -a /etc/shells >/dev/null
+	fi
+
+	if [ "${SHELL:-}" != "$brew_bash" ]; then
+		print_colored "$YELLOW" "Changing default shell to $brew_bash..."
+		chsh -s "$brew_bash"
+	fi
+}
+
+install_dependencies_linux() {
+	if command_exists nala; then
+		sudo_cmd nala install -y bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists apt-get; then
+		sudo_cmd apt-get update
+		sudo_cmd apt-get install -y bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists dnf; then
+		sudo_cmd dnf install -y bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists yum; then
+		sudo_cmd yum install -y bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists pacman; then
+		sudo_cmd pacman -S --needed bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists zypper; then
+		sudo_cmd zypper install -y bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists emerge; then
+		sudo_cmd emerge --ask=n app-shells/bash-completion sys-apps/bat app-text/tree app-text/multitail app-misc/fastfetch app-editors/neovim app-misc/trash-cli app-shells/fzf app-shells/zoxide
+	elif command_exists xbps-install; then
+		sudo_cmd xbps-install -Sy bash-completion bat tree multitail fastfetch neovim trash-cli fzf zoxide
+	elif command_exists nix-env; then
+		nix-env -iA nixpkgs.bash-completion nixpkgs.bat nixpkgs.tree nixpkgs.multitail nixpkgs.fastfetch nixpkgs.neovim nixpkgs.trash-cli nixpkgs.fzf nixpkgs.zoxide
+	else
+		print_colored "$RED" "Can't find a supported package manager."
+		return 1
+	fi
+}
+
+install_dependencies() {
+	case $OS_NAME in
+	Darwin)
+		install_dependencies_macos
+		;;
+	Linux)
+		install_dependencies_linux
+		;;
+	*)
+		print_colored "$RED" "Unsupported operating system: $OS_NAME"
+		return 1
+		;;
+	esac
+}
+
+backup_existing() {
+	target=$1
+	if [ -e "$target" ] || [ -L "$target" ]; then
+		backup="$target.bak.$(date +%Y%m%d%H%M%S)"
+		mv "$target" "$backup"
+		print_colored "$YELLOW" "Backed up $target to $backup"
+	fi
+}
+
+link_file() {
+	source=$1
+	target=$2
+	target_dir=$(dirname -- "$target")
+
+	mkdir -p "$target_dir"
+
+	if [ -L "$target" ]; then
+		if [ "$(readlink "$target")" = "$source" ]; then
+			return 0
+		fi
+		rm "$target"
+	elif [ -e "$target" ]; then
+		backup_existing "$target"
+	fi
+
+	ln -s "$source" "$target"
+	print_colored "$GREEN" "Linked $target"
+}
+
+ensure_bash_profile_sources_bashrc() {
+	[ "$OS_NAME" = Darwin ] || return 0
+
+	profile=$HOME/.bash_profile
+	if [ -f "$profile" ] && grep -q 'HOME/.bashrc' "$profile"; then
+		return 0
+	fi
+
+	{
+		printf '\n# Source .bashrc for interactive bash shells\n'
+		printf '%s\n' "if [ -f \"\$HOME/.bashrc\" ]; then"
+		printf '%s\n' ". \"\$HOME/.bashrc\""
+		printf 'fi\n'
+	} >>"$profile"
+	print_colored "$GREEN" "Updated $profile to source .bashrc"
+}
+
+ensure_bash_profile_brew_shellenv() {
+	[ "$OS_NAME" = Darwin ] || return 0
+
+	profile=$HOME/.bash_profile
+	if [ -f "$profile" ] && grep -q 'brew shellenv' "$profile"; then
+		return 0
+	fi
+
+	{
+		printf '\n# Configure Homebrew for login shells\n'
+		printf 'if [ -x /opt/homebrew/bin/brew ]; then\n'
+		printf '%s\n' "eval \"\$(/opt/homebrew/bin/brew shellenv)\""
+		printf 'elif [ -x /usr/local/bin/brew ]; then\n'
+		printf '%s\n' "eval \"\$(/usr/local/bin/brew shellenv)\""
+		printf 'fi\n'
+	} >>"$profile"
+	print_colored "$GREEN" "Updated $profile with Homebrew shellenv"
+}
+
+install_configs() {
+	mkdir -p "$MYBASHDIR"
+	cp -p "$SCRIPT_DIR/.bashrc" "$MYBASHDIR/.bashrc"
+	cp -p "$SCRIPT_DIR/starship.toml" "$MYBASHDIR/starship.toml"
+	cp -p "$SCRIPT_DIR/config.jsonc" "$MYBASHDIR/config.jsonc"
+	cp -p "$SCRIPT_DIR/README.md" "$MYBASHDIR/README.md"
+	cp -p "$SCRIPT_DIR/setup.sh" "$MYBASHDIR/setup.sh"
+	cp -p "$SCRIPT_DIR/uninstall.sh" "$MYBASHDIR/uninstall.sh"
+	chmod +x "$MYBASHDIR/setup.sh" "$MYBASHDIR/uninstall.sh"
+
+	link_file "$MYBASHDIR/.bashrc" "$HOME/.bashrc"
+	link_file "$MYBASHDIR/starship.toml" "$HOME/.config/starship.toml"
+	link_file "$MYBASHDIR/config.jsonc" "$HOME/.config/fastfetch/config.jsonc"
+	ensure_homebrew_bash_macos
+	ensure_bash_profile_brew_shellenv
+	ensure_bash_profile_sources_bashrc
+}
+
+install_dependencies
+install_configs
+
+print_colored "$GREEN" "Installation complete. Restart your shell or run: source ~/.bashrc"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,141 +6,155 @@ RED=$(tput setaf 1)
 YELLOW=$(tput setaf 3)
 GREEN=$(tput setaf 2)
 
-LINUXTOOLBOXDIR="$HOME/linuxtoolbox"
+MYBASHDIR="$HOME/.local/share/mybash"
 PACKAGER=""
 SUDO_CMD=""
 
 print_colored() {
-    color=$1
-    message=$2
-    printf "${color}%s${RC}\n" "$message"
+	color=$1
+	message=$2
+	printf "${color}%s${RC}\n" "$message"
 }
 
 command_exists() {
-    command -v "$1" >/dev/null 2>&1
+	command -v "$1" >/dev/null 2>&1
 }
 
 determine_package_manager() {
-    PACKAGEMANAGER='nala apt dnf yum pacman zypper emerge xbps-install nix-env'
-    for pgm in $PACKAGEMANAGER; do
-        if command_exists "$pgm"; then
-            PACKAGER="$pgm"
-            printf "Using %s\n" "$pgm"
-            break
-        fi
-    done
+	PACKAGEMANAGER='brew nala apt dnf yum pacman zypper emerge xbps-install nix-env'
+	for pgm in ${PACKAGEMANAGER}; do
+		if command_exists "$pgm"; then
+			PACKAGER="$pgm"
+			printf "Using %s\n" "$pgm"
+			break
+		fi
+	done
 
-    if [ -z "$PACKAGER" ]; then
-        print_colored "$RED" "Can't find a supported package manager"
-        exit 1
-    fi
+	if [ -z "$PACKAGER" ]; then
+		print_colored "$RED" "Can't find a supported package manager"
+		exit 1
+	fi
 }
 
 determine_sudo_command() {
-    if command_exists sudo; then
-        SUDO_CMD="sudo"
-    elif command_exists doas && [ -f "/etc/doas.conf" ]; then
-        SUDO_CMD="doas"
-    else
-        SUDO_CMD="su -c"
-    fi
+	if command_exists sudo; then
+		SUDO_CMD="sudo"
+	elif command_exists doas && [ -f "/etc/doas.conf" ]; then
+		SUDO_CMD="doas"
+	else
+		SUDO_CMD="su -c"
+	fi
 
-    printf "Using %s as privilege escalation software\n" "$SUDO_CMD"
+	printf "Using %s as privilege escalation software\n" "$SUDO_CMD"
+}
+
+run_privileged() {
+	if [ "$SUDO_CMD" = "su -c" ]; then
+		su -c "$*"
+	else
+		"$SUDO_CMD" "$@"
+	fi
 }
 
 uninstall_dependencies() {
-    DEPENDENCIES='bash-completion bat tree multitail fastfetch neovim trash-cli'
+	set -- bash-completion bat tree multitail fastfetch neovim trash-cli
 
-    print_colored "$YELLOW" "Uninstalling dependencies..."
-    if [ "$PACKAGER" = "pacman" ]; then
-        if command_exists yay; then
-            yay -Rns --noconfirm ${DEPENDENCIES}
-        elif command_exists paru; then
-            paru -Rns --noconfirm ${DEPENDENCIES}
-        else
-            ${SUDO_CMD} pacman -Rns --noconfirm ${DEPENDENCIES}
-        fi
-    elif [ "$PACKAGER" = "nala" ] || [ "$PACKAGER" = "apt" ]; then
-        ${SUDO_CMD} ${PACKAGER} purge -y ${DEPENDENCIES}
-    elif [ "$PACKAGER" = "emerge" ]; then
-        ${SUDO_CMD} ${PACKAGER} --deselect app-shells/bash-completion sys-apps/bat app-text/tree app-text/multitail app-misc/fastfetch app-editors/neovim app-misc/trash-cli
-    elif [ "$PACKAGER" = "xbps-install" ]; then
-        ${SUDO_CMD} xbps-remove -Ry ${DEPENDENCIES}
-    elif [ "$PACKAGER" = "nix-env" ]; then
-        ${SUDO_CMD} ${PACKAGER} -e bash-completion bat tree multitail fastfetch neovim trash-cli
-    elif [ "$PACKAGER" = "dnf" ] || [ "$PACKAGER" = "yum" ]; then
-        ${SUDO_CMD} ${PACKAGER} remove -y ${DEPENDENCIES}
-    else
-        ${SUDO_CMD} ${PACKAGER} remove -y ${DEPENDENCIES}
-    fi
+	print_colored "$YELLOW" "Uninstalling dependencies..."
+	if [ "$PACKAGER" = "brew" ]; then
+		brew uninstall --ignore-dependencies bash-completion bash-completion@2 bat tree multitail fastfetch neovim trash fzf zoxide starship || true
+	elif [ "$PACKAGER" = "pacman" ]; then
+		if command_exists yay; then
+			yay -Rns --noconfirm "$@"
+		elif command_exists paru; then
+			paru -Rns --noconfirm "$@"
+		else
+			run_privileged pacman -Rns --noconfirm "$@"
+		fi
+	elif [ "$PACKAGER" = "nala" ] || [ "$PACKAGER" = "apt" ]; then
+		run_privileged "$PACKAGER" purge -y "$@"
+	elif [ "$PACKAGER" = "emerge" ]; then
+		run_privileged "$PACKAGER" --deselect app-shells/bash-completion sys-apps/bat app-text/tree app-text/multitail app-misc/fastfetch app-editors/neovim app-misc/trash-cli
+	elif [ "$PACKAGER" = "xbps-install" ]; then
+		run_privileged xbps-remove -Ry "$@"
+	elif [ "$PACKAGER" = "nix-env" ]; then
+		run_privileged "$PACKAGER" -e "$@"
+	elif [ "$PACKAGER" = "dnf" ] || [ "$PACKAGER" = "yum" ]; then
+		run_privileged "$PACKAGER" remove -y "$@"
+	else
+		run_privileged "$PACKAGER" remove -y "$@"
+	fi
 }
 
 uninstall_font() {
-    FONT_NAME="MesloLGS Nerd Font Mono"
-    FONT_DIR="$HOME/.local/share/fonts/$FONT_NAME"
-    
-    if [ -d "$FONT_DIR" ]; then
-        print_colored "$YELLOW" "Removing font: $FONT_NAME"
-        rm -rf "$FONT_DIR"
-        fc-cache -fv
-        print_colored "$GREEN" "Font removed: $FONT_NAME"
-    else
-        print_colored "$YELLOW" "Font not found: $FONT_NAME"
-    fi
+	FONT_NAME="MesloLGS Nerd Font Mono"
+	FONT_DIR="$HOME/.local/share/fonts/$FONT_NAME"
+
+	if [ -d "$FONT_DIR" ]; then
+		print_colored "$YELLOW" "Removing font: $FONT_NAME"
+		rm -rf "$FONT_DIR"
+		fc-cache -fv
+		print_colored "$GREEN" "Font removed: $FONT_NAME"
+	else
+		print_colored "$YELLOW" "Font not found: $FONT_NAME"
+	fi
 }
 
 uninstall_starship_and_fzf() {
-    if command_exists starship; then
-        print_colored "$YELLOW" "Uninstalling Starship..."
-        ${SUDO_CMD} rm -f "$(command -v starship)"
-        print_colored "$GREEN" "Starship uninstalled"
-    fi
+	if command_exists starship; then
+		print_colored "$YELLOW" "Uninstalling Starship..."
+		run_privileged rm -f "$(command -v starship)"
+		print_colored "$GREEN" "Starship uninstalled"
+	fi
 
-    if [ -d "$HOME/.fzf" ]; then
-        print_colored "$YELLOW" "Uninstalling fzf..."
-        "$HOME/.fzf/uninstall"
-        rm -rf "$HOME/.fzf"
-        print_colored "$GREEN" "fzf uninstalled"
-    fi
+	if [ -d "$HOME/.fzf" ]; then
+		print_colored "$YELLOW" "Uninstalling fzf..."
+		"$HOME/.fzf/uninstall"
+		rm -rf "$HOME/.fzf"
+		print_colored "$GREEN" "fzf uninstalled"
+	fi
 }
 
 uninstall_zoxide() {
-    if command_exists zoxide; then
-        print_colored "$YELLOW" "Uninstalling Zoxide..."
-        ${SUDO_CMD} rm -f "$(command -v zoxide)"
-        print_colored "$GREEN" "Zoxide uninstalled"
-    fi
+	if command_exists zoxide; then
+		print_colored "$YELLOW" "Uninstalling Zoxide..."
+		run_privileged rm -f "$(command -v zoxide)"
+		print_colored "$GREEN" "Zoxide uninstalled"
+	fi
 }
 
 remove_configs() {
-    USER_HOME=$(getent passwd "${SUDO_USER:-$USER}" | cut -d: -f6)
-    
-    print_colored "$YELLOW" "Removing configuration files..."
-    
-    # Remove .bashrc symlink and restore backup if it exists
-    if [ -L "$USER_HOME/.bashrc" ]; then
-        rm "$USER_HOME/.bashrc"
-        if [ -f "$USER_HOME/.bashrc.bak" ]; then
-            mv "$USER_HOME/.bashrc.bak" "$USER_HOME/.bashrc"
-            print_colored "$GREEN" "Restored original .bashrc"
-        fi
-    fi
-    
-    # Remove starship config
-    rm -f "$USER_HOME/.config/starship.toml"
-    
-    # Remove fastfetch config
-    rm -f "$USER_HOME/.config/fastfetch/config.jsonc"
-    
-    print_colored "$GREEN" "Configuration files removed"
+	if command_exists getent; then
+		USER_HOME=$(getent passwd "${SUDO_USER:-$USER}" | cut -d: -f6)
+	else
+		USER_HOME=${HOME}
+	fi
+
+	print_colored "$YELLOW" "Removing configuration files..."
+
+	# Remove .bashrc symlink and restore backup if it exists
+	if [ -L "$USER_HOME/.bashrc" ]; then
+		rm "$USER_HOME/.bashrc"
+		if [ -f "$USER_HOME/.bashrc.bak" ]; then
+			mv "$USER_HOME/.bashrc.bak" "$USER_HOME/.bashrc"
+			print_colored "$GREEN" "Restored original .bashrc"
+		fi
+	fi
+
+	# Remove starship config
+	rm -f "$USER_HOME/.config/starship.toml"
+
+	# Remove fastfetch config
+	rm -f "$USER_HOME/.config/fastfetch/config.jsonc"
+
+	print_colored "$GREEN" "Configuration files removed"
 }
 
-remove_linuxtoolbox() {
-    if [ -d "$LINUXTOOLBOXDIR" ]; then
-        print_colored "$YELLOW" "Removing linuxtoolbox directory..."
-        rm -rf "$LINUXTOOLBOXDIR"
-        print_colored "$GREEN" "linuxtoolbox directory removed"
-    fi
+remove_mybash_data() {
+	if [ -d "$MYBASHDIR" ]; then
+		print_colored "$YELLOW" "Removing mybash data directory..."
+		rm -rf "$MYBASHDIR"
+		print_colored "$GREEN" "mybash data directory removed"
+	fi
 }
 
 # Main execution
@@ -151,6 +165,6 @@ uninstall_font
 uninstall_starship_and_fzf
 uninstall_zoxide
 remove_configs
-remove_linuxtoolbox
+remove_mybash_data
 
 print_colored "$GREEN" "Uninstallation complete. Please restart your shell for changes to take effect."


### PR DESCRIPTION
## Summary
- add a portable `setup.sh` installer and install into `~/.local/share/mybash`
- add macOS Homebrew bootstrap, Bash 5 installation, `/etc/shells` registration, and default-shell switching
- make `.bashrc` tolerate macOS/BSD command differences while preserving Linux paths
- update uninstall and README docs for the new macOS install flow

## Validation
- `brew install shellcheck shfmt`
- `bash -n .bashrc`
- `sh -n setup.sh`
- `sh -n uninstall.sh`
- `shellcheck .bashrc setup.sh uninstall.sh`
- `shfmt -d .bashrc setup.sh uninstall.sh`
- `find . -name '*.sh' -print0 | xargs -0 shellcheck -f gcc`
- `./setup.sh`
- installed-copy syntax checks under `~/.local/share/mybash`
- Homebrew Bash login check: `/opt/homebrew/bin/bash` reports Bash 5.3.15 on this Mac
