### PR TITLE
Add alias to delete Zone.Identifier files in WSL

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -389,6 +389,9 @@ docker-clean() {
 # alias to fix ~/.ssh permissions
 alias sshperms='cd ~ && chmod 600 ~/.ssh/* && chmod 700 ~/.ssh && chmod 644 ~/.ssh/*.pub'
 
+# delete those pesky Zone.Identifier files that happen with WSL
+alias unzone='find . -name "*:Zone.Identifier" -type f -delete'
+
 #######################################################
 # SPECIAL FUNCTIONS
 #######################################################


### PR DESCRIPTION
Moving files to WSL using the Windows file manager GUI can result in duplicate files ending in Zone.Identifier.  This alias simply removes those duplicate files